### PR TITLE
[#3] Fix guide styling

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,8 +14,5 @@
 //
 //= require jquery
 //= require jquery_ujs
-//# = require jquery.ui.autocomplete
-//= jquery-jvert-tabs-1.1.4
 //= require mustache
-//= require_tree .
-//
+//= require jquery-jvert-tabs-1.1.4


### PR DESCRIPTION
**Trello**: https://trello.com/c/K8Llw7c6/3-fix-broken-styling-for-guides

**Currently on [CFA staging](http://hnlanswers-stage.herokuapp.com/)**

---

Application.js was loading all of the scripts in app/assets/javascripts.

This included the Markdown scripts which were only used for the CMS and already required explicitly in active_admin.js

Removing the require_tree call from `application.js` fixed the problem.  

There's an example of it working on CFA staging [here](http://hnlanswers-stage.herokuapp.com/guides/sample-guide)
