### PR TITLE
[#9] Fallback to no related articles if #search throws exception

### DIFF
--- a/app/jobs/report_exception_job.rb
+++ b/app/jobs/report_exception_job.rb
@@ -1,0 +1,9 @@
+class ReportExceptionJob < Struct.new(:exception)
+  def self.schedule(exception)
+    Delayed::Job.enqueue ReportExceptionJob.new(exception)
+  end
+
+  def perform
+    Rollbar.report_exception exception
+  end
+end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -71,8 +71,8 @@ class Article < ActiveRecord::Base
   def self.search( query )
     begin
       self.search_tank query
-    rescue SocketError
-      logger.error "Could not communicate with IndexTank service"
+    rescue Exception => exception
+      ErrorService.report(exception)
       []
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,7 @@ module Honoluluanswers
 
     # Custom directories with classes and modules you want to be autoloadable.
     config.autoload_paths += Dir["#{config.root}/lib", "#{config.root}/lib/**/"]
+    config.autoload_paths << "#{config.root}/app/jobs"
 
     # Only load the plugins named here, in the order given (default is alphabetical).
     # :all can be used as a placeholder for all plugins not explicitly named.

--- a/lib/error_service.rb
+++ b/lib/error_service.rb
@@ -1,0 +1,13 @@
+# Public: Wrapper for the exception handling service, Rollbar
+class ErrorService
+  def self.report(exception)
+    Rails.logger.error(exception.inspect)
+    ReportExceptionJob.schedule(exception) if send_to_external?
+  end
+
+  private
+
+  def self.send_to_external?
+    Rails.env.production? || Rails.env.staging?
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/6E2j3yVC
## 

This adds a new ErrorService object, which is used to report exceptions. ErrorService#report(Exception)

When in development, ErrorService will simply log the exception. When in staging or production, the exception will be reported to Rollbar, our exception handling service.
### Why not schedule the job directly?

Calls to Delayed::Job are now isolated to one class, so if we use some other async. mechanism or the DJ API  changes it's only called in one place.
### Why not call Rollbar directly?

Calling Rollbar in the same thread as the request response would be a Bad Idea™, since it would tie our level of service to Rollbar's. Also, we might swap Rollbar for something else.
