### PR TITLE
[#39] Writers can edit any article if it is a Draft

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -17,8 +17,8 @@ class Ability
 
     if user.is_writer
       can :create, articles + [Category, Contact, GuideStep]
-      can [:update, :destroy], articles, status: "Draft", user_id: user.id
-      can [:update, :destroy], GuideStep, guide: { user_id: user.id, status: "Draft" }
+      can [:update, :destroy], articles, :status => "Draft"
+      can [:update, :destroy], GuideStep, :guide =>  { status: "Draft" }
     end
 
   end


### PR DESCRIPTION
Trello: https://trello.com/c/QmV6DnRl

---

There is a bug where if you are a writer and you create an article you can no longer edit it. This is because no user_id is being set on the article when it is saved, it can only be set by an admin who then edits the article.

Conveniently, it was decided that writers should be able to edit any article, even those they did not originally create.

Therefore this fix simply removes the constraint from CanCan that the article must belong to the given user.

There still remains a bug however that the writer of the article is not being set.  This is documented by https://trello.com/c/i8tGalgt
