### PR TITLE
[#5] Use generic "Update" text for all types of article (cms, admin user)

### DIFF
--- a/app/views/shared/admin/_article_actions.html.erb
+++ b/app/views/shared/admin/_article_actions.html.erb
@@ -88,7 +88,7 @@
     <ol>
       <li class="commit button">
       <input class="update" id="submit" name="commit" type="submit"
-      value="Update Quick answer">
+      value="Update">
       </li>
     </ol>
   </fieldset>


### PR DESCRIPTION
Trello: https://trello.com/c/1pfy7vdz

---

This fixes the issue where an article button says "Update Quick Answer" when the article is a Web Service or Guide.  It is only an issue for admin users.

Now, we just show "Update".
